### PR TITLE
Reduce Bevy dependencies and update bevy_atmosphere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["game-engines", "rendering"]
 exclude = ["assets"]
 
 [dependencies]
-bevy = { version = "0.6", default-features = false, features = ["render"] }
+bevy = { version = "0.6", default-features = false, features = ["bevy_core_pipeline", "bevy_render", "bevy_pbr"] }
 
 [dev-dependencies]
-bevy = { version = "0.6", default-features = true, features = ["jpeg"] }
+bevy = { version = "0.6", default-features = false, features = ["bevy_gltf", "jpeg", "png", "x11"] }
 bevy_full_throttle = { git = "https://github.com/lightsoutgames/bevy_full_throttle" }
 bevy_flycam = "0.6.0"
 smooth-bevy-cameras = "0.2.0"
-bevy_atmosphere = { git = "https://github.com/cryscan/bevy_atmosphere" }
+bevy_atmosphere = "0.2"


### PR DESCRIPTION
Previously used `render` feature is a [group](
https://github.com/bevyengine/bevy/blob/a291b5aaedb4affcb31df2e2e63cb0c665ffb24a/Cargo.toml#L35-L43) that contains unneeded stuff, like `bevy_ui` or `bevy_text`. Specified features in this PR is the required minimum. You can read more about in in this issue: https://github.com/bevyengine/bevy/issues/4202

Also bevy_atmosphere has bumped its version, so now it contains your PR.