### PR TITLE
Option to suppress temporal restir accumulation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,6 +234,8 @@ pub struct HikariConfig {
     pub emissive_threshold: f32,
     /// Threshold for the indirect luminance to reduce fireflies.
     pub max_indirect_luminance: f32,
+    /// Whether to do temporal sample reuse in ReSTIR.
+    pub suppress_temporal_accum: bool,
     /// Whether to do spatial sample reuse in ReSTIR.
     pub spatial_reuse: bool,
     /// Whether to perform spatial denoise for direct illumination.
@@ -254,6 +256,7 @@ impl Default for HikariConfig {
             solar_angle: PI / 36.0,
             emissive_threshold: 0.00390625,
             max_indirect_luminance: 1.0,
+            suppress_temporal_accum: false,
             spatial_reuse: false,
             direct_spatial_denoise: true,
             indirect_spatial_denoise: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ pub struct HikariConfig {
     /// Threshold for the indirect luminance to reduce fireflies.
     pub max_indirect_luminance: f32,
     /// Whether to do temporal sample reuse in ReSTIR.
-    pub suppress_temporal_accum: bool,
+    pub temporal_reuse: bool,
     /// Whether to do spatial sample reuse in ReSTIR.
     pub spatial_reuse: bool,
     /// Whether to perform spatial denoise for direct illumination.
@@ -256,7 +256,7 @@ impl Default for HikariConfig {
             solar_angle: PI / 36.0,
             emissive_threshold: 0.00390625,
             max_indirect_luminance: 1.0,
-            suppress_temporal_accum: false,
+            temporal_reuse: true,
             spatial_reuse: false,
             direct_spatial_denoise: true,
             indirect_spatial_denoise: true,

--- a/src/shaders/light.wgsl
+++ b/src/shaders/light.wgsl
@@ -803,6 +803,7 @@ fn temporal_restir(
         surface,
         s.radiance
     );
+
     out.w_new = luminance(out.radiance) / pdf;
 
     let depth_ratio = (*r).s.visible_position.w / s.visible_position.w;
@@ -1089,7 +1090,9 @@ fn direct_lit(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
         restir = temporal_restir(&r, view_direction, surface, s, candidate.p, frame.max_temporal_reuse_count);
     }
 
-    store_reservoir(coords.x + size.x * coords.y, r);
+    if (frame.suppress_temporal_accum == 0u) {
+        store_reservoir(coords.x + size.x * coords.y, r);
+    }
 
     var output_color = 255.0 * surface.emissive.a * surface.emissive.rgb;
     output_color += restir.output;
@@ -1195,7 +1198,10 @@ fn indirect_lit_ambient(@builtin(global_invocation_id) invocation_id: vec3<u32>)
     let previous_uv = uv - velocity;
     r = load_previous_reservoir(previous_uv, reservoir_size);
     let restir = temporal_restir(&r, view_direction, surface, s, p1 * p2, frame.max_temporal_reuse_count);
-    store_reservoir(coords.x + reservoir_size.x * coords.y, r);
+
+    if (frame.suppress_temporal_accum == 0u) {
+        store_reservoir(coords.x + reservoir_size.x * coords.y, r);
+    }
 
     // To display temporal output for debugging
     let output_color = restir.output;

--- a/src/shaders/light.wgsl
+++ b/src/shaders/light.wgsl
@@ -1090,7 +1090,7 @@ fn direct_lit(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
         restir = temporal_restir(&r, view_direction, surface, s, candidate.p, frame.max_temporal_reuse_count);
     }
 
-    if (frame.suppress_temporal_accum == 0u) {
+    if (frame.suppress_temporal_reuse == 0u) {
         store_reservoir(coords.x + size.x * coords.y, r);
     }
 
@@ -1199,7 +1199,7 @@ fn indirect_lit_ambient(@builtin(global_invocation_id) invocation_id: vec3<u32>)
     r = load_previous_reservoir(previous_uv, reservoir_size);
     let restir = temporal_restir(&r, view_direction, surface, s, p1 * p2, frame.max_temporal_reuse_count);
 
-    if (frame.suppress_temporal_accum == 0u) {
+    if (frame.suppress_temporal_reuse == 0u) {
         store_reservoir(coords.x + reservoir_size.x * coords.y, r);
     }
 

--- a/src/shaders/mesh_view_types.wgsl
+++ b/src/shaders/mesh_view_types.wgsl
@@ -5,12 +5,12 @@ struct Frame {
     clear_color: vec4<f32>,
     number: u32,
     validation_interval: u32,
+    suppress_temporal_reuse: u32,
     max_temporal_reuse_count: u32,
     max_spatial_reuse_count: u32,
     direct_oversample_threshold: u32,
     solar_angle: f32,
     max_indirect_luminance: f32,
-    suppress_temporal_accum: u32,
 };
 
 struct PreviousView {

--- a/src/shaders/mesh_view_types.wgsl
+++ b/src/shaders/mesh_view_types.wgsl
@@ -10,6 +10,7 @@ struct Frame {
     direct_oversample_threshold: u32,
     solar_angle: f32,
     max_indirect_luminance: f32,
+    suppress_temporal_accum: u32,
 };
 
 struct PreviousView {

--- a/src/view.rs
+++ b/src/view.rs
@@ -76,12 +76,12 @@ pub struct FrameUniform {
     pub clear_color: Vec4,
     pub number: u32,
     pub validation_interval: u32,
+    pub suppress_temporal_reuse: u32,
     pub max_temporal_reuse_count: u32,
     pub max_spatial_reuse_count: u32,
     pub direct_oversample_threshold: u32,
     pub solar_angle: f32,
     pub max_indirect_luminance: f32,
-    pub suppress_temporal_accum: u32,
 }
 
 #[derive(Default)]
@@ -122,7 +122,7 @@ fn prepare_frame_uniform(
         direct_oversample_threshold,
         solar_angle,
         max_indirect_luminance,
-        suppress_temporal_accum,
+        temporal_reuse,
         ..
     } = config.into_inner().clone();
 
@@ -130,7 +130,7 @@ fn prepare_frame_uniform(
     let max_temporal_reuse_count = max_temporal_reuse_count as u32;
     let max_spatial_reuse_count = max_spatial_reuse_count as u32;
     let direct_oversample_threshold = direct_oversample_threshold as u32;
-    let suppress_temporal_accum = if suppress_temporal_accum { 1u32 } else { 0u32 };
+    let suppress_temporal_reuse = if temporal_reuse { 0 } else { 1 };
 
     uniform.buffer.set(FrameUniform {
         kernel: Mat3 {
@@ -146,7 +146,7 @@ fn prepare_frame_uniform(
         direct_oversample_threshold,
         solar_angle,
         max_indirect_luminance,
-        suppress_temporal_accum,
+        suppress_temporal_reuse,
     });
     uniform.buffer.write_buffer(&render_device, &render_queue);
     counter.0 += 1;

--- a/src/view.rs
+++ b/src/view.rs
@@ -81,6 +81,7 @@ pub struct FrameUniform {
     pub direct_oversample_threshold: u32,
     pub solar_angle: f32,
     pub max_indirect_luminance: f32,
+    pub suppress_temporal_accum: u32,
 }
 
 #[derive(Default)]
@@ -121,6 +122,7 @@ fn prepare_frame_uniform(
         direct_oversample_threshold,
         solar_angle,
         max_indirect_luminance,
+        suppress_temporal_accum,
         ..
     } = config.into_inner().clone();
 
@@ -128,6 +130,7 @@ fn prepare_frame_uniform(
     let max_temporal_reuse_count = max_temporal_reuse_count as u32;
     let max_spatial_reuse_count = max_spatial_reuse_count as u32;
     let direct_oversample_threshold = direct_oversample_threshold as u32;
+    let suppress_temporal_accum = if suppress_temporal_accum { 1u32 } else { 0u32 };
 
     uniform.buffer.set(FrameUniform {
         kernel: Mat3 {
@@ -143,6 +146,7 @@ fn prepare_frame_uniform(
         direct_oversample_threshold,
         solar_angle,
         max_indirect_luminance,
+        suppress_temporal_accum,
     });
     uniform.buffer.write_buffer(&render_device, &render_queue);
     counter.0 += 1;


### PR DESCRIPTION
Now with
```wgsl
suppress_temporal_accum: true,
spatial_reuse: false,
direct_spatial_denoise: false,
indirect_spatial_denoise: false,
temporal_anti_aliasing: false,
```
we see pure path tracing results