### PR TITLE
force bvh 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ warn_mesh_load = []
 [dependencies]
 bytemuck = "1.9"
 itertools = "0.10"
-bvh = "0.7.1"
+bvh = "= 0.7.1"
 bitflags = "1.3"
 serde = "1.0"
 serde_variant = "0.1.1"


### PR DESCRIPTION
Cargo will use bvh 0.7.2 this is a problem because it needs glem 0.23 when every thing else uses glem 0.22
fixes #93 